### PR TITLE
Many improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,17 +2,9 @@ buildscript {
     repositories {
         jcenter()
         maven { url = "http://files.minecraftforge.net/maven" }
-        
-          maven { // Mantle, TCon, JEI
-   				 name 'DVS1 Maven FS'
-   				 url 'https://dvs1.progwml6.com/files/maven/'
-  }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
-        
-       	
-    
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
@@ -43,39 +35,31 @@ minecraft {
      mappings = "stable_39"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
-    repositories {
-          maven { // Mantle, TCon, JEI
-   				 name 'DVS1 Maven FS'
-   				 url 'http://dvs1.progwml6.com/files/maven/'
-  }
-  }
+
+eclipse.project {
+  buildCommand 'org.eclipse.buildship.core.gradleprojectbuilder'
+  natures 'org.eclipse.buildship.core.gradleprojectnature'
+}
+
+idea.module {
+  downloadJavadoc = true
+  //inheritOutputDirs = true
+}
+
+repositories {
+    maven { // Mantle, TCon, JEI
+        name 'DVS1 Maven FS'
+        url 'http://dvs1.progwml6.com/files/maven/'
+    }
+}
+
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      deobfProvided ("slimeknights:TConstruct:${mc_version}-${tconstruct_version}:deobf") {
+    deobfCompile ("slimeknights:TConstruct:${mc_version}-${tconstruct_version}:deobf") {
       	  exclude group: 'mezz.jei'
     }
-    	deobfProvided ("slimeknights.mantle:Mantle:${mantle_version}:deobf") {
-    	    exclude group: 'mezz.jei'
+  	deobfCompile ("slimeknights.mantle:Mantle:${mantle_version}:deobf") {
+        exclude group: 'mezz.jei'
     }
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // the deobf configurations:  'deobfCompile' and 'deobfProvided' are the same as the normal compile and provided,
-    // except that these dependencies get remapped to your current MCP mappings
-    //deobfCompile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-    //deobfProvided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
-
 }
 
 processResources {


### PR DESCRIPTION
1) Fix Tinkers so it'll load in runClient/runServer
2) Make it so gradlew eclipse will add a gradle nature when run (Allows for import as eclipse project to end up dealing with gradle stuff automatically)
3) Make it so gradlew idea will download javadoc for dependencies
4) Remove unneeded cruft and other detritus